### PR TITLE
Revert "Bump github.com/tencentcloud/tencentcloud-sdk-go from 1.0.152 to 1.0.173 (#34)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	github.com/hashicorp/hcl/v2 v2.10.0
 	github.com/hashicorp/packer-plugin-sdk v0.2.3
 	github.com/pkg/errors v0.9.1
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v0.0.0-20210531003256-78c3f12c3f55
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v0.0.0-20210531003256-78c3f12c3f55
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v0.0.0-20210531003256-78c3f12c3f55
+	github.com/tencentcloud/tencentcloud-sdk-go v1.0.152
 	github.com/zclconf/go-cty v1.8.3
 )

--- a/go.sum
+++ b/go.sum
@@ -357,12 +357,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v0.0.0-20210531003256-78c3f12c3f55 h1:Hd3B4lOvSv5t43HNtAvNiC/kKSZGS+1TSaaMKbspn1E=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v0.0.0-20210531003256-78c3f12c3f55/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v0.0.0-20210531003256-78c3f12c3f55 h1:ke4BCTi8fpK05UsJ1z82ZElkI8J615cw784G1CsYkkA=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v0.0.0-20210531003256-78c3f12c3f55/go.mod h1:AqyM/ZZMD7q5mHBqNY9YImbSpEpoEe7E/vrTbUWX+po=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v0.0.0-20210531003256-78c3f12c3f55 h1:l2rSf0I8XESs1U4Uc4X10l+gNwuOX85uaZGplfJJ/a0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v0.0.0-20210531003256-78c3f12c3f55/go.mod h1:SKgeSsIfPEM6BeoIFiGHsWG9UsEXzkK0SkWx51H/OS8=
+github.com/tencentcloud/tencentcloud-sdk-go v1.0.152 h1:KvE9QPx37yLL+aB6ty5sTjx/p6iCZD0t2Jb1q37BJiE=
+github.com/tencentcloud/tencentcloud-sdk-go v1.0.152/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.2.4 h1:cTciPbZ/VSOzCLKclmssnfQ/jyoVyOcJ3aoJyUV1Urc=
 github.com/ugorji/go v1.2.4/go.mod h1:EuaSCk8iZMdIspsu6HXH7X2UGKw1ezO4wCfGszGmmo4=


### PR DESCRIPTION
This reverts commit 5b317f0b3bf8ee35210bb7a421360a1baa6400ef. The changes in the reverted commit caused go mod issues. So it is being reverted back to a known working state.
