### PR TITLE
fix env variable name of tencentcloud secret id

### DIFF
--- a/builder/tencentcloud/cvm/access_config.go
+++ b/builder/tencentcloud/cvm/access_config.go
@@ -46,7 +46,7 @@ var ValidRegions = []Region{
 
 type TencentCloudAccessConfig struct {
 	// Tencentcloud secret id. You should set it directly,
-	// or set the TENCENTCLOUD_ACCESS_KEY environment variable.
+	// or set the TENCENTCLOUD_SECRET_ID environment variable.
 	SecretId string `mapstructure:"secret_id" required:"true"`
 	// Tencentcloud secret key. You should set it directly,
 	// or set the TENCENTCLOUD_SECRET_KEY environment variable.

--- a/builder/tencentcloud/examples/basic-with-data-disk.json
+++ b/builder/tencentcloud/examples/basic-with-data-disk.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "secret_id": "{{env `TENCENTCLOUD_ACCESS_KEY`}}",
+    "secret_id": "{{env `TENCENTCLOUD_SECRET_ID`}}",
     "secret_key": "{{env `TENCENTCLOUD_SECRET_KEY`}}"
   },
   "builders": [

--- a/builder/tencentcloud/examples/basic.json
+++ b/builder/tencentcloud/examples/basic.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "secret_id": "{{env `TENCENTCLOUD_ACCESS_KEY`}}",
+    "secret_id": "{{env `TENCENTCLOUD_SECRET_ID`}}",
     "secret_key": "{{env `TENCENTCLOUD_SECRET_KEY`}}"
   },
   "builders": [

--- a/builder/tencentcloud/examples/centos.json
+++ b/builder/tencentcloud/examples/centos.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "secret_id": "{{env `TENCENTCLOUD_ACCESS_KEY`}}",
+    "secret_id": "{{env `TENCENTCLOUD_SECRET_ID`}}",
     "secret_key": "{{env `TENCENTCLOUD_SECRET_KEY`}}"
   },
   "builders": [

--- a/docs-partials/builder/tencentcloud/cvm/TencentCloudAccessConfig-required.mdx
+++ b/docs-partials/builder/tencentcloud/cvm/TencentCloudAccessConfig-required.mdx
@@ -1,7 +1,7 @@
 <!-- Code generated from the comments of the TencentCloudAccessConfig struct in builder/tencentcloud/cvm/access_config.go; DO NOT EDIT MANUALLY -->
 
 - `secret_id` (string) - Tencentcloud secret id. You should set it directly,
-  or set the TENCENTCLOUD_ACCESS_KEY environment variable.
+  or set the TENCENTCLOUD_SECRET_ID environment variable.
 
 - `secret_key` (string) - Tencentcloud secret key. You should set it directly,
   or set the TENCENTCLOUD_SECRET_KEY environment variable.

--- a/docs/builders/cvm.mdx
+++ b/docs/builders/cvm.mdx
@@ -23,7 +23,7 @@ a [communicator](/docs/templates/legacy_json_templates/communicator) can be conf
 ### Required:
 
 - `secret_id` (string) - Tencentcloud secret id. You should set it directly,
-  or set the `TENCENTCLOUD_ACCESS_KEY` environment variable.
+  or set the `TENCENTCLOUD_SECRET_ID` environment variable.
 
 - `secret_key` (string) - Tencentcloud secret key. You should set it directly,
   or set the `TENCENTCLOUD_SECRET_KEY` environment variable.
@@ -151,7 +151,7 @@ Here is a basic example for Tencentcloud.
 ```json
 {
   "variables": {
-    "secret_id": "{{env `TENCENTCLOUD_ACCESS_KEY`}}",
+    "secret_id": "{{env `TENCENTCLOUD_SECRET_ID`}}",
     "secret_key": "{{env `TENCENTCLOUD_SECRET_KEY`}}"
   },
   "builders": [

--- a/example/build.pkr.hcl
+++ b/example/build.pkr.hcl
@@ -1,6 +1,6 @@
 variable "secret_id" {
   type    = string
-  default = "${env("TENCENTCLOUD_ACCESS_KEY")}"
+  default = "${env("TENCENTCLOUD_SECRET_ID")}"
 }
 
 variable "secret_key" {


### PR DESCRIPTION
In the Go code, `tencentcloud secret id` is written as `TENCENTCLOUD_SECRET_ID` , but in the documentation and examples, it is written as `TENCENTCLOUD_ACCESS_KEY` .

