### PR TITLE
docs: fix references to internal documentation

### DIFF
--- a/builder/tencentcloud/cvm/run_config.go
+++ b/builder/tencentcloud/cvm/run_config.go
@@ -92,7 +92,7 @@ type TencentCloudRunConfig struct {
 	RunTags map[string]string `mapstructure:"run_tags" required:"false"`
 	// Same as [`run_tags`](#run_tags) but defined as a singular repeatable
 	// block containing a `key` and a `value` field. In HCL2 mode the
-	// [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+	// [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
 	// will allow you to create those programatically.
 	RunTag config.KeyValues `mapstructure:"run_tag" required:"false"`
 

--- a/docs-partials/builder/tencentcloud/cvm/TencentCloudRunConfig-not-required.mdx
+++ b/docs-partials/builder/tencentcloud/cvm/TencentCloudRunConfig-not-required.mdx
@@ -67,7 +67,7 @@
 
 - `run_tag` ([]{key string, value string}) - Same as [`run_tags`](#run_tags) but defined as a singular repeatable
   block containing a `key` and a `value` field. In HCL2 mode the
-  [`dynamic_block`](/docs/templates/hcl_templates/expressions#dynamic-blocks)
+  [`dynamic_block`](/packer/docs/templates/hcl_templates/expressions#dynamic-blocks)
   will allow you to create those programatically.
 
 - `ssh_private_ip` (bool) - SSH Private Ip

--- a/docs/builders/cvm.mdx
+++ b/docs/builders/cvm.mdx
@@ -18,7 +18,7 @@ customized images based on an existing base images.
 
 The following configuration options are available for building Tencentcloud images.
 In addition to the options listed here,
-a [communicator](/docs/templates/legacy_json_templates/communicator) can be configured for this builder.
+a [communicator](/packer/docs/templates/legacy_json_templates/communicator) can be configured for this builder.
 
 ### Required:
 


### PR DESCRIPTION
With the move to developer.hashicorp.com some links between the general doc and plugins were broken. This PR fixes them