### PR TITLE
Mark integration as archived

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -7,6 +7,7 @@ integration {
   name = "Tencent Cloud"
   description = "The Tencent Cloud plugin provides the capability to build customized images based on an existing base images."
   identifier = "packer/hashicorp/tencentcloud"
+  flags      = ["archived"]
   component {
     type = "builder"
     name = "Tencent Cloud Builder"


### PR DESCRIPTION
In accordance with the communication that we sent to the parent organization we are mark this plugin as archived to denote that we are not actively maintaining it. If a community member is open to taking over this integration we can discuss the transfer process. 