### PR TITLE
Allow CLOUD_BSSD and CLOUD_HSSD as system disks

### DIFF
--- a/builder/tencentcloud/cvm/run_config.go
+++ b/builder/tencentcloud/cvm/run_config.go
@@ -110,7 +110,7 @@ type TencentCloudRunConfig struct {
 }
 
 var ValidCBSType = []string{
-	"LOCAL_BASIC", "LOCAL_SSD", "CLOUD_BASIC", "CLOUD_SSD", "CLOUD_PREMIUM",
+	"LOCAL_BASIC", "LOCAL_SSD", "CLOUD_BASIC", "CLOUD_SSD", "CLOUD_PREMIUM", "CLOUD_BSSD", "CLOUD_HSSD",
 }
 
 func (cf *TencentCloudRunConfig) Prepare(ctx *interpolate.Context) []error {


### PR DESCRIPTION
Needed in order to use e.g. SA5 or S8 instances.

Fixes #132
